### PR TITLE
Fix icon overflows input bug

### DIFF
--- a/lib/components/input/input.module.scss
+++ b/lib/components/input/input.module.scss
@@ -1,5 +1,6 @@
 .inputContainer {
   position: relative;
+  width: fit-content;
 
   $paddingX: 0.5rem;
   $paddingY: 0.25rem;
@@ -15,6 +16,7 @@
   $iconRHeight: calc(var(--iconRSize, 0) * 1px);
 
   .input {
+    width: inherit;
     min-height: calc(max($iconLHeight, $iconRHeight) + calc($paddingY * 2));
     padding-top: $paddingY;
     padding-bottom: $paddingY;


### PR DESCRIPTION
The bug was being caused by the inner input element not matching the width of its container. Adding fit-content on the container to make it default to the input size, and inherit to the input for when the container grows