### PR TITLE
Memoize context provider values

### DIFF
--- a/lib/components/data-editing-context/data-editing-context-provider.tsx
+++ b/lib/components/data-editing-context/data-editing-context-provider.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, createContext, useState } from 'react';
+import { PropsWithChildren, createContext, useMemo, useState } from 'react';
 
 export interface KeyValue {
   [key: string]: unknown;
@@ -78,10 +78,19 @@ export function DataEditingContextProvider({ children }: PropsWithChildren) {
     setUpdates({});
   };
 
+  const value = useMemo(
+    () => ({
+      editing,
+      updates,
+      handleChange,
+      openEditMode,
+      cancelEditMode,
+    }),
+    [editing, updates],
+  );
+
   return (
-    <DataEditingContext.Provider
-      value={{ editing, updates, handleChange, openEditMode, cancelEditMode }}
-    >
+    <DataEditingContext.Provider value={value}>
       {children}
     </DataEditingContext.Provider>
   );

--- a/lib/components/expanding-context/expanding-context-provider.tsx
+++ b/lib/components/expanding-context/expanding-context-provider.tsx
@@ -3,6 +3,7 @@ import {
   PropsWithChildren,
   SetStateAction,
   createContext,
+  useMemo,
   useState,
 } from 'react';
 
@@ -50,9 +51,10 @@ export function ExpandingContextProvider({
   children,
 }: PropsWithChildren<ExpandingContextProviderProps>) {
   const [expanded, setExpanded] = useState<boolean>(isExpanded);
+  const value = useMemo(() => ({ expanded, setExpanded }), [expanded]);
 
   return (
-    <ExpandingContext.Provider value={{ expanded, setExpanded }}>
+    <ExpandingContext.Provider value={value}>
       {children}
     </ExpandingContext.Provider>
   );

--- a/lib/components/outside-click-handler/outside-click-handler.spec.tsx
+++ b/lib/components/outside-click-handler/outside-click-handler.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OutsideClickHandler } from './outside-click-handler';
 
@@ -33,7 +33,7 @@ describe(OutsideClickHandler.name, () => {
     const insideElement = screen.getByTestId('inside');
     await user.click(insideElement);
 
-    expect(mockOnOutsideClick).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockOnOutsideClick).not.toHaveBeenCalled());
   });
 
   it('should call onOutsideClick() when outside clicked', async () => {
@@ -52,6 +52,6 @@ describe(OutsideClickHandler.name, () => {
     const outsideElement = screen.getByTestId('outside');
     await user.click(outsideElement);
 
-    expect(mockOnOutsideClick).toHaveBeenCalledOnce();
+    await waitFor(() => expect(mockOnOutsideClick).toHaveBeenCalledOnce());
   });
 });

--- a/lib/components/wizard-context/wizard-context-provider.spec.tsx
+++ b/lib/components/wizard-context/wizard-context-provider.spec.tsx
@@ -103,7 +103,9 @@ describe(WizardContextProvider.name, () => {
       for (let i = 0; i < currentStep; i++) await user.click(nextStep);
 
       const stepIndex = screen.getByTestId('step-index');
-      expect(stepIndex.innerHTML).toEqual(currentStep.toString());
+      await waitFor(() =>
+        expect(stepIndex.innerHTML).toEqual(currentStep.toString()),
+      );
 
       const prevStep = screen.getByTestId('prev-step');
       await user.click(prevStep);
@@ -147,7 +149,9 @@ describe(WizardContextProvider.name, () => {
       for (let i = 0; i < currentStep; i++) await user.click(nextStep);
 
       const stepIndex = screen.getByTestId('step-index');
-      expect(stepIndex.innerHTML).toEqual(currentStep.toString());
+      await waitFor(() =>
+        expect(stepIndex.innerHTML).toEqual(currentStep.toString()),
+      );
 
       const reset = screen.getByTestId('reset');
       await user.click(reset);

--- a/lib/components/wizard-context/wizard-context-provider.tsx
+++ b/lib/components/wizard-context/wizard-context-provider.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, createContext, useState } from 'react';
+import { PropsWithChildren, createContext, useMemo, useState } from 'react';
 import { KeyValue } from '../data-editing-context/data-editing-context-provider';
 import { useDataEditingContext } from '../data-editing-context/use-data-editing-context';
 import { withDataEditingContext } from '../data-editing-context/with-data-editing-context';
@@ -72,34 +72,32 @@ export const WizardContextProvider = withDataEditingContext(function ({
   children,
 }: PropsWithChildren) {
   const { updates, handleChange, cancelEditMode } = useDataEditingContext();
-
   const [stepIndex, setStepIndex] = useState<number>(0);
 
-  const prevStep = () => setStepIndex((prev) => Math.max(prev - 1, 0));
-  const nextStep = () => setStepIndex((prev) => prev + 1);
+  const value = useMemo(() => {
+    const prevStep = () => setStepIndex((prev) => Math.max(prev - 1, 0));
+    const nextStep = () => setStepIndex((prev) => prev + 1);
 
-  const reset = () => {
-    /*
+    const reset = () => {
+      /*
       Sets updates/values to an empty object. It also sets the editing variable
       of DataEditingContext to false, but we are not using that value so it
       does not matter.
     */
-    cancelEditMode();
-    setStepIndex(0);
-  };
+      cancelEditMode();
+      setStepIndex(0);
+    };
+    return {
+      values: updates,
+      handleChange,
+      stepIndex,
+      prevStep,
+      nextStep,
+      reset,
+    };
+  }, [cancelEditMode, handleChange, stepIndex, updates]);
 
   return (
-    <WizardContext.Provider
-      value={{
-        values: updates,
-        handleChange,
-        stepIndex,
-        prevStep,
-        nextStep,
-        reset,
-      }}
-    >
-      {children}
-    </WizardContext.Provider>
+    <WizardContext.Provider value={value}>{children}</WizardContext.Provider>
   );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@portfolijo/react-comp-lib",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@portfolijo/react-comp-lib",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portfolijo/react-comp-lib",
   "private": false,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "main": "dist/react-comp-lib.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
Memoized the value of all context providers in order to maintain the object identity when the provider rerenders due to something other than its internal state.

See:
https://stackoverflow.com/questions/62230532/is-usememo-required-to-manage-state-via-the-context-api-in-reactjs
https://www.reddit.com/r/reactjs/comments/zzcgr2/why_is_usememo_commonlyused_in_reacts_context/