### PR TITLE
Fix horizontal scrollbar on header bug

### DIFF
--- a/lib/components/table/table.module.scss
+++ b/lib/components/table/table.module.scss
@@ -17,6 +17,7 @@
 
     .tableHeader {
       overflow-y: auto;
+      overflow-x: hidden;
       scrollbar-gutter: stable;
     }
   }

--- a/lib/components/table/table.module.scss
+++ b/lib/components/table/table.module.scss
@@ -16,9 +16,10 @@
     grid-template-columns: repeat($numCols, 1fr) auto;
 
     .tableHeader {
-      overflow-y: auto;
-      overflow-x: hidden;
       scrollbar-gutter: stable;
+      overflow-y: auto;
+      // Prevents X-scrollbar when columns are minmax(0, 1fr) and constrained.
+      overflow-x: hidden;
     }
   }
 
@@ -36,7 +37,7 @@
   .tableBody {
     grid-auto-rows: min-content;
     overflow-y: auto;
-    // Prevents X-scrollbar when Y-scrollbar is visible (in Firefox).
+    // Prevents X-scrollbar when Y-scrollbar is visible.
     overflow-x: hidden;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@portfolijo/react-comp-lib",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@portfolijo/react-comp-lib",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "ISC",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portfolijo/react-comp-lib",
   "private": false,
-  "version": "5.0.2",
+  "version": "5.0.3",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
Fixing bug where header renders a horizontal scrollbar when the table has minmax(0, 1fr) in grid-template-columns.